### PR TITLE
[12.0][FIX] - set brand for down payment invoices

### DIFF
--- a/sale_brand/__init__.py
+++ b/sale_brand/__init__.py
@@ -2,3 +2,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import models
+from . import wizard

--- a/sale_brand/__init__.py
+++ b/sale_brand/__init__.py
@@ -3,3 +3,4 @@
 
 from . import models
 from . import wizard
+from . import tests

--- a/sale_brand/tests/__init__.py
+++ b/sale_brand/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_order

--- a/sale_brand/tests/test_sale_order.py
+++ b/sale_brand/tests/test_sale_order.py
@@ -1,0 +1,35 @@
+# Copyright 2019 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestSaleOrder(TransactionCase):
+    def setUp(self):
+        super(TestSaleOrder, self).setUp()
+        self.sale = self.env.ref('sale.sale_order_1')
+        self.sale.brand_id = self.env['res.brand'].create({'name': 'brand'})
+        self.sale.order_line.mapped('product_id').write(
+            {'invoice_policy': 'order'}
+        )
+        self.sale.action_confirm()
+
+    def test_create_invoice(self):
+        """It should create branded invoice"""
+        self.assertEqual(self.sale.invoice_status, 'to invoice')
+        invoice_ids = self.sale.action_invoice_create()
+        invoice = self.env['account.invoice'].browse(invoice_ids[0])
+        self.assertEqual(invoice.brand_id, self.sale.brand_id)
+
+    def test_create_down_payment_invoice(self):
+        """It should create branded down-payment invoice"""
+        advance_payment_wizard = self.env['sale.advance.payment.inv'].create(
+            {'advance_payment_method': 'fixed', 'amount': 10.0}
+        )
+        advance_payment_wizard.with_context(
+            active_ids=self.sale.ids
+        ).create_invoices()
+        invoice = self.sale.order_line.mapped('invoice_lines').mapped(
+            'invoice_id'
+        )
+        self.assertEqual(invoice.brand_id, self.sale.brand_id)

--- a/sale_brand/wizard/__init__.py
+++ b/sale_brand/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_make_invoice_advance

--- a/sale_brand/wizard/sale_make_invoice_advance.py
+++ b/sale_brand/wizard/sale_make_invoice_advance.py
@@ -1,0 +1,15 @@
+# Copyright 2019 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class SaleAdvancePaymentInv(models.TransientModel):
+    _inherit = "sale.advance.payment.inv"
+
+    @api.multi
+    def _create_invoice(self, order, so_line, amount):
+        invoice = super()._create_invoice(order, so_line, amount)
+        invoice.brand_id = order.brand_id
+        invoice._onchange_partner_id()
+        return invoice


### PR DESCRIPTION
This PR fix the issue where a down-payment invoice is created for a branded sale order without a brand set. It improve unit tests as well.