### PR TITLE
[12.0][IMP] Add Company field to Brand form

### DIFF
--- a/brand/views/res_brand.xml
+++ b/brand/views/res_brand.xml
@@ -21,6 +21,11 @@
             <xpath expr="//field[@name='parent_id']" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>
+
+            <xpath expr="//field[@name='function']" position="before">
+                <field name="company_id"/>
+            </xpath>
+
         </field>
     </record>
 

--- a/brand/views/res_brand.xml
+++ b/brand/views/res_brand.xml
@@ -23,7 +23,7 @@
             </xpath>
 
             <xpath expr="//field[@name='function']" position="before">
-                <field name="company_id"/>
+                <field name="company_id"  options="{'no_create': True}" groups="base.group_multi_company"/>
             </xpath>
 
         </field>


### PR DESCRIPTION
In a multicompany scenario, a brand could invisibly be assigned to
the current company, preventing it from being shared with other
companies.

Exposing the Company field makes it easy for users to apply the
appropriate setting for their needs.