### PR TITLE
[12.0][FIX] Create credit note with brand

### DIFF
--- a/account_brand/models/account_invoice.py
+++ b/account_brand/models/account_invoice.py
@@ -23,3 +23,13 @@ class AccountInvoice(models.Model):
         if self.type in ('in_invoice', 'in_refund'):
             return False
         return super(AccountInvoice, self)._is_brand_required()
+
+    @api.model
+    def _prepare_refund(self, invoice, date_invoice=None, date=None,
+                        description=None, journal_id=None):
+        values = super(AccountInvoice, self)._prepare_refund(
+            invoice, date_invoice=date_invoice, date=date,
+            description=description, journal_id=journal_id)
+        if invoice.brand_id:
+            values['brand_id'] = invoice.brand_id.id
+        return values

--- a/account_brand/tests/test_brand_mixin.py
+++ b/account_brand/tests/test_brand_mixin.py
@@ -102,3 +102,16 @@ class TestBrandMixin(TransactionCase):
         )
         doc = etree.XML(view['arch'])
         self.assertTrue(doc.xpath("//field[@name='brand_use_level']"))
+
+    def test_refund_invoice(self):
+        invoice = self.env['account.invoice'].create(
+            {
+                'name': "Sample invoice",
+                'company_id': self.company.id,
+                'journal_id': self.journal.id,
+                'partner_id': self.partner.id,
+                'brand_id': self.brand.id,
+            }
+        )
+        credit_note = invoice.refund()
+        self.assertEqual(credit_note.brand_id, self.brand)


### PR DESCRIPTION
Fix a bug where brand was not set when creating a credit note from an invoice.
If brand is required in config, then creating credit notes from invoices was not possible.