### PR TITLE
[12.0][FIX] - run brand change in finalize invoice

### DIFF
--- a/sale_brand/models/sale_order.py
+++ b/sale_brand/models/sale_order.py
@@ -41,3 +41,10 @@ class SaleOrder(models.Model):
     def _onchange_team_id(self):
         if not self.brand_id and self.team_id.brand_id:
             self.brand_id = self.team_id.brand_id
+
+    @api.multi
+    def _finalize_invoices(self, invoices, references):
+        res = super()._finalize_invoices(invoices, references)
+        for invoice in invoices.values():
+            invoice._onchange_partner_brand()
+        return res


### PR DESCRIPTION
when an invoice is created from a so, onchange_partner_id is called in _finalize_invoices
which override the account selected by _onchange_partner_brand. we need to call it here