### PR TITLE
[FIX] Bug wrong logo display on kanban view

### DIFF
--- a/brand/views/res_brand.xml
+++ b/brand/views/res_brand.xml
@@ -60,7 +60,7 @@
     <record model="ir.actions.act_window" id="res_brand_act_window">
         <field name="name">Brands</field>
         <field name="res_model">res.brand</field>
-        <field name="view_mode">kanban,tree,form</field>
+        <field name="view_mode">tree,form</field>
         <field name="context">{'default_customer': 0, 'default_supplier': 0,}</field>
     </record>
     <record model="ir.ui.menu" id="res_brand_menu">


### PR DESCRIPTION
The id of brand and partner are different. In Kanban View the logo image is based on partner_id but value passed is of brand id. Thus the logo displayed is not good. 
I think the kanban view is not necessary, beacause we have a few number of brand and we use this view only on configuration purpose (few time).  