### PR TITLE
[14.0] Improvements setting Brand use level

### DIFF
--- a/account_brand/tests/test_brand_mixin.py
+++ b/account_brand/tests/test_brand_mixin.py
@@ -6,7 +6,10 @@ from lxml import etree
 from odoo.exceptions import ValidationError
 from odoo.tests.common import Form, TransactionCase
 
-from odoo.addons.brand.models.res_company import BRAND_USE_LEVEL_REQUIRED_LEVEL
+from odoo.addons.brand.models.res_company import (
+    BRAND_USE_LEVEL_NO_USE_LEVEL,
+    BRAND_USE_LEVEL_REQUIRED_LEVEL,
+)
 
 
 class TestBrandMixin(TransactionCase):
@@ -138,3 +141,14 @@ class TestBrandMixin(TransactionCase):
         action = reverse.reverse_moves()
         credit_note = self.env["account.move"].browse(action.get("res_id"))
         self.assertEqual(credit_note.brand_id, self.brand)
+
+    def test_default_get(self):
+        self.company.brand_use_level = BRAND_USE_LEVEL_REQUIRED_LEVEL
+
+        move = Form(self.env["account.move"])
+        self.assertEqual(move.brand_use_level, BRAND_USE_LEVEL_NO_USE_LEVEL)
+
+        move = Form(
+            self.env["account.move"].with_context(default_company_id=self.company.id)
+        )
+        self.assertEqual(move.brand_use_level, BRAND_USE_LEVEL_REQUIRED_LEVEL)

--- a/brand/models/res_brand_mixin.py
+++ b/brand/models/res_brand_mixin.py
@@ -21,7 +21,6 @@ class ResBrandMixin(models.AbstractModel):
     )
     brand_use_level = fields.Selection(
         string="Brand Use Level",
-        default=BRAND_USE_LEVEL_NO_USE_LEVEL,
         related="company_id.brand_use_level",
     )
     company_id = fields.Many2one(
@@ -31,6 +30,22 @@ class ResBrandMixin(models.AbstractModel):
     def _is_brand_required(self):
         self.ensure_one()
         return self.company_id.brand_use_level == BRAND_USE_LEVEL_REQUIRED_LEVEL
+
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+
+        if "brand_use_level" not in res:
+            brand_use_level = False
+
+            if res.get("company_id", False):
+                company = self.env["res.company"].browse(res["company_id"])
+                brand_use_level = company.brand_use_level
+            else:
+                brand_use_level = BRAND_USE_LEVEL_NO_USE_LEVEL
+
+            res["brand_use_level"] = brand_use_level
+
+        return res
 
     @api.constrains("brand_id", "company_id")
     def _check_brand_requirement(self):


### PR DESCRIPTION
If the company is set in a brand mixin model,
the brand_use_level is set via the default_get method with data from the company setting