### PR TITLE
[FIX] account_brand: Allow to selecting the Analytic Account on Lines

### DIFF
--- a/account_brand/models/account_move.py
+++ b/account_brand/models/account_move.py
@@ -68,7 +68,8 @@ class AccountMove(models.Model):
         for invoice in self:
             if invoice.state == "draft" and invoice.brand_id:
                 account_analytic = invoice.brand_id.analytic_account_id
-                invoice.invoice_line_ids.update(
-                    {"analytic_account_id": account_analytic.id}
-                )
+                if account_analytic:
+                    invoice.invoice_line_ids.update(
+                        {"analytic_account_id": account_analytic.id}
+                    )
         return res


### PR DESCRIPTION
Issue:
 - If the Analytic account is not set on the brand record
 - On Invoice/Bill -> Select the brand -> Goto -> Lines -> select Analytic Account
 - Can't allow to selecting Analytic Account on Lines
 
 Expected Result:
 - Should Allow to selecting Analytic Account on Lines if Analytic account is not set on the brand