### PR TITLE
[14.0] [IMP] `product_brand`: better position for group by filter in sale.report

### DIFF
--- a/product_brand/reports/sale_report_view.xml
+++ b/product_brand/reports/sale_report_view.xml
@@ -4,9 +4,9 @@
         <field name="inherit_id" ref="sale.view_order_product_search" />
         <field name="model">sale.report</field>
         <field name="arch" type="xml">
-            <filter name="Customer" position="after">
+            <filter name="Category" position="after">
                 <filter
-                    string="Brand"
+                    string="Product Brand"
                     name="brand"
                     context="{'group_by':'product_brand_id'}"
                 />


### PR DESCRIPTION
It doesn't make sense to have this filter between Customer and Customer Industry.
A more logical sense is to have it next to Product, Product Category, ..

![image](https://user-images.githubusercontent.com/1914185/168142537-1f68c8ed-39c8-40c3-bc96-4f2de267f6f0.png)
