### PR TITLE
sale_brand: issue with create payment on sale with required brand

### DIFF
--- a/sale_brand/tests/test_sale_order.py
+++ b/sale_brand/tests/test_sale_order.py
@@ -8,6 +8,7 @@ class TestSaleOrder(TransactionCase):
     def setUp(self):
         super(TestSaleOrder, self).setUp()
         self.sale = self.env.ref("sale.sale_order_1")
+        self.sale.company_id.brand_use_level = "required"
         self.sale.brand_id = self.env["res.brand"].create({"name": "brand"})
         self.sale.order_line.mapped("product_id").write({"invoice_policy": "order"})
         self.sale.action_confirm()

--- a/sale_brand/wizard/sale_make_invoice_advance.py
+++ b/sale_brand/wizard/sale_make_invoice_advance.py
@@ -7,8 +7,7 @@ from odoo import models
 class SaleAdvancePaymentInv(models.TransientModel):
     _inherit = "sale.advance.payment.inv"
 
-    def _create_invoice(self, order, so_line, amount):
-        invoice = super()._create_invoice(order, so_line, amount)
-        invoice.brand_id = order.brand_id
-        invoice._onchange_partner_id()
-        return invoice
+    def _prepare_invoice_values(self, order, name, amount, so_line):
+        res = super()._prepare_invoice_values(order, name, amount, so_line)
+        res["brand_id"] = order.brand_id.id
+        return res


### PR DESCRIPTION
Currently, we got an error when we try to create an advance invoice on sale order with required brand :

https://github.com/OCA/brand/runs/8201947948?check_suite_focus=true#step:8:142