### PR TITLE
[FIX] Adding tags to unittests for account_brand and sale_brand

### DIFF
--- a/account_brand/tests/test_account_analytic_move.py
+++ b/account_brand/tests/test_account_analytic_move.py
@@ -1,9 +1,11 @@
 # Copyright 2019 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from odoo.tests import tagged
 from odoo.tests.common import SavepointCase
 
 
+@tagged("post_install", "-at_install")
 class TestAccountAnalyticMove(SavepointCase):
     def setUp(self):
         super().setUp()

--- a/account_brand/tests/test_account_move.py
+++ b/account_brand/tests/test_account_move.py
@@ -1,9 +1,11 @@
 # Copyright 2019 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from odoo.tests import tagged
 from odoo.tests.common import SavepointCase
 
 
+@tagged("post_install", "-at_install")
 class TestAccountMove(SavepointCase):
     def setUp(self):
         super(TestAccountMove, self).setUp()

--- a/account_brand/tests/test_brand_mixin.py
+++ b/account_brand/tests/test_brand_mixin.py
@@ -4,6 +4,7 @@
 from lxml import etree
 
 from odoo.exceptions import ValidationError
+from odoo.tests import tagged
 from odoo.tests.common import Form, TransactionCase
 
 from odoo.addons.brand.models.res_company import (
@@ -12,6 +13,7 @@ from odoo.addons.brand.models.res_company import (
 )
 
 
+@tagged("post_install", "-at_install")
 class TestBrandMixin(TransactionCase):
     def setUp(self):
         super(TestBrandMixin, self).setUp()

--- a/sale_brand/tests/test_sale_order.py
+++ b/sale_brand/tests/test_sale_order.py
@@ -1,9 +1,11 @@
 # Copyright 2019 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
 
 
+@tagged("post_install", "-at_install")
 class TestSaleOrder(TransactionCase):
     def setUp(self):
         super(TestSaleOrder, self).setUp()


### PR DESCRIPTION
If you do
`odoo -i account_brand --stop-after-init --test-enable`
or
`odoo -i sale_brand --stop-after-init --test-enable`

The unittests for
account_brand:
TestAccountAnalyticMove.test_move_analytic_account_onchange_brand
TestAccountMove.test_on_change_partner_id
TestBrandMixin.test_default_get
TestBrandMixin.test_reverse_move

sale_brand:
TestSaleOrder.test_create_down_payment_invoice
TestSaleOrder.test_create_invoice

will fail because of missing account.journal entries.
This was already discussed here. https://github.com/OCA/contract/pull/876