### PR TITLE
[FIX] Updated `transfer_field_to_modifiers` method signature

### DIFF
--- a/brand/models/res_brand_mixin.py
+++ b/brand/models/res_brand_mixin.py
@@ -54,8 +54,9 @@ class ResBrandMixin(models.AbstractModel):
 
     def setup_modifiers(self, node, field=None):
         modifiers = {}
+        attributes = ["invisible", "readonly", "required"]
         if field is not None:
-            ir_ui_view.transfer_field_to_modifiers(field, modifiers)
+            ir_ui_view.transfer_field_to_modifiers(field, modifiers, attributes)
         ir_ui_view.transfer_node_to_modifiers(node, modifiers)
         ir_ui_view.transfer_modifiers_to_node(modifiers, node)
 


### PR DESCRIPTION
This addresses a method signature in `base` that has recently been changed in Odoo 16.

See: https://github.com/OCA/brand/issues/142