### PR TITLE
[FIX][16.0] brand

### DIFF
--- a/brand/models/res_brand_mixin.py
+++ b/brand/models/res_brand_mixin.py
@@ -69,16 +69,26 @@ class ResBrandMixin(models.AbstractModel):
 
         if view_type in ["tree", "form"]:
             doc = etree.XML(result["arch"])
-            for node in doc.xpath("//field[@name='brand_id']"):
+            for node in doc.xpath(
+                """
+                //field[@name='brand_id']
+                [not(ancestor::*[@widget='one2many' or @widget='many2many'])]
+            """
+            ):
                 elem = etree.Element(
-                    "field", {"name": "brand_use_level", "invisible": "True"}
+                    "field",
+                    {
+                        "name": "brand_use_level",
+                        "invisible": "True",
+                        "string": _("Brand Use Level"),
+                    },
                 )
                 brand_use_level_field = self.fields_get(["brand_use_level"])[
                     "brand_use_level"
                 ]
                 brand_id_field = self.fields_get(["brand_id"])["brand_id"]
-                self.setup_modifiers(elem, field=brand_use_level_field)
                 node.addprevious(elem)
+                self.setup_modifiers(elem, field=brand_use_level_field)
                 node.set(
                     "attrs",
                     '{"invisible": '


### PR DESCRIPTION
There are currently some bugs with the 16.0 branch of odoo.
1. All fields have to have the string attribute defined in the python or in the xml, odoo does not generate them automatically any more. This commit adds that field to the "brand_use_level" generated in the "get_view" function of the "res_brand_mixin.py" file.
2. Now check the fields in the views, and currently the function "get_view" has a bug, if you have the field "brand_id" in a subview either a M2O and/or M2M, with this fix we would omit all the "brand_id" that as a parent have a field that contains widget=many2many or widget=one2many, I know this is not the best way and we could find some other way, but I have not seen that anyone has reported this bug and at least give a solution.
3. Invisible column "brand_use_level", It did not become invisible and gave an error, with the new XML check.