### PR TITLE
[16.0][brand_external_report_layout][FIX] Add missing sudo() in template

### DIFF
--- a/brand_external_report_layout/views/report_template.xml
+++ b/brand_external_report_layout/views/report_template.xml
@@ -14,7 +14,7 @@
             <t t-else="" t-set="brand_id" t-value="0" />
             <t
                 t-if="o and 'brand_id' in o.fields_get() and o.brand_id and o.brand_id.external_report_layout_id"
-                t-call="{{o.brand_id.external_report_layout_id.key}}"
+                t-call="{{o.brand_id.external_report_layout_id.sudo().key}}"
             >
                 <t t-set="company" t-value="o.brand_id.sudo()" />
                 <t t-raw="0" />


### PR DESCRIPTION
The inherited external layout template attempts to read a field "key" from a Brand's `external_report_layout_id`, which is an `ir.ui.view` record, which by standard Odoo most users do not have read access on.

The result is users with limited permissions receive an unrelated access error when rendering external PDF reports.