### PR TITLE
[16.0][FIX] add is_company_detail_empty boolean computed field on res.brand

### DIFF
--- a/brand_external_report_layout/models/res_brand.py
+++ b/brand_external_report_layout/models/res_brand.py
@@ -68,12 +68,18 @@ class ResBrand(models.Model):
         string="Brand Details",
         help="Header text displayed at the top of all reports.",
     )
+    is_company_details_empty = fields.Boolean(compute='_compute_empty_company_details')
     layout_background = fields.Selection(
         [("Blank", "Blank"), ("Geometric", "Geometric"), ("Custom", "Custom")],
         default="Blank",
         required=True,
     )
     layout_background_image = fields.Binary("Background Image")
+
+    @api.depends('company_details')
+    def _compute_empty_company_details(self):
+        for record in self:
+            record.is_company_details_empty = not html2plaintext(record.company_details or '')
 
     def change_report_template(self):
         self.ensure_one()

--- a/brand_external_report_layout/models/res_brand.py
+++ b/brand_external_report_layout/models/res_brand.py
@@ -5,7 +5,6 @@ import base64
 import os
 
 from odoo import _, api, fields, models, tools
-from odoo.tools import html2plaintext
 
 
 class ResBrand(models.Model):
@@ -69,7 +68,7 @@ class ResBrand(models.Model):
         string="Brand Details",
         help="Header text displayed at the top of all reports.",
     )
-    is_company_details_empty = fields.Boolean(compute='_compute_empty_company_details')
+    is_company_details_empty = fields.Boolean(compute="_compute_empty_company_details")
     layout_background = fields.Selection(
         [("Blank", "Blank"), ("Geometric", "Geometric"), ("Custom", "Custom")],
         default="Blank",
@@ -77,10 +76,12 @@ class ResBrand(models.Model):
     )
     layout_background_image = fields.Binary("Background Image")
 
-    @api.depends('company_details')
+    @api.depends("company_details")
     def _compute_empty_company_details(self):
         for record in self:
-            record.is_company_details_empty = not html2plaintext(record.company_details or '')
+            record.is_company_details_empty = not tools.html2plaintext(
+                record.company_details or ""
+            )
 
     def change_report_template(self):
         self.ensure_one()

--- a/brand_external_report_layout/models/res_brand.py
+++ b/brand_external_report_layout/models/res_brand.py
@@ -5,6 +5,7 @@ import base64
 import os
 
 from odoo import _, api, fields, models, tools
+from odoo.tools import html2plaintext
 
 
 class ResBrand(models.Model):


### PR DESCRIPTION
The field works like on res.company model and prevents the following error (encountered on branded sale.order PDF report print) :

Traceback (most recent call last):
  File "<198>", line 304, in template_198
  File "<198>", line 76, in template_198_content
AttributeError: 'res.brand' object has no attribute 'is_company_details_empty'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/odoo/auto/addons/web/controllers/report.py", line 113, in report_download
    response = self.report_routes(reportname, docids=docids, converter=converter, context=context)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 697, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/opt/odoo/auto/addons/web/controllers/report.py", line 42, in report_routes
    pdf = report.with_context(context)._render_qweb_pdf(reportname, docids, data=data)[0]
  File "/opt/odoo/auto/addons/account/models/ir_actions_report.py", line 58, in _render_qweb_pdf
    return super()._render_qweb_pdf(report_ref, res_ids=res_ids, data=data)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_actions_report.py", line 819, in _render_qweb_pdf
    collected_streams = self._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
  File "/opt/odoo/auto/addons/account_invoice_facturx/models/ir_actions_report.py", line 17, in _render_qweb_pdf_prepare_streams
    collected_streams = super()._render_qweb_pdf_prepare_streams(
  File "/opt/odoo/auto/addons/account_edi_ubl_cii/models/ir_actions_report.py", line 58, in _render_qweb_pdf_prepare_streams
    collected_streams = super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
  File "/opt/odoo/auto/addons/account_edi/models/ir_actions_report.py", line 14, in _render_qweb_pdf_prepare_streams
    collected_streams = super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
  File "/opt/odoo/auto/addons/account/models/ir_actions_report.py", line 20, in _render_qweb_pdf_prepare_streams
    return super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_actions_report.py", line 708, in _render_qweb_pdf_prepare_streams
    html = self.with_context(**additional_context)._render_qweb_html(report_ref, res_ids_wo_stream, data=data)[0]
  File "/opt/odoo/auto/addons-dev/enterprise/web_studio/models/ir_actions_report.py", line 19, in _render_qweb_html
    return super(IrActionsReport, self)._render_qweb_html(report_ref, docids, data)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_actions_report.py", line 896, in _render_qweb_html
    return self._render_template(report.report_name, data), 'html'
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_actions_report.py", line 623, in _render_template
    return view_obj._render_template(template, values).encode()
  File "/opt/odoo/auto/addons/website/models/ir_ui_view.py", line 420, in _render_template
    return super()._render_template(template, values=values)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_ui_view.py", line 2125, in _render_template
    return self.env['ir.qweb']._render(template, values)
  File "/opt/odoo/custom/src/odoo/odoo/tools/profiler.py", line 292, in _tracked_method_render
    return method_render(self, template, values, **options)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_qweb.py", line 581, in _render
    result = ''.join(rendering)
  File "<1107>", line 80, in template_1107
  File "<1107>", line 62, in template_1107_content
  File "<1107>", line 50, in template_1107_t_call_0
  File "<1106>", line 1662, in template_1106
  File "<1106>", line 1651, in template_1106_content
  File "<202>", line 150, in template_202
  File "<202>", line 106, in template_202_content
  File "<198>", line 310, in template_198
odoo.addons.base.models.ir_qweb.QWebException: Error while render the template
AttributeError: 'res.brand' object has no attribute 'is_company_details_empty'
Template: web.external_layout_striped
Path: /t/div[1]/div/div[2]/ul/li[1]
Node: <li t-if="company.is_company_details_empty"/>

This field is used in report layout templates [web/views/report_templates.xml](https://github.com/odoo/odoo/blob/16.0/addons/web/views/report_templates.xml) at lines 303, 349, 392, 415 and 446. Native `company` is replaced by the record `brand_id` in [brand_external_report_layout/views/report_template.xml](https://github.com/OCA/brand/blob/671aa63b3061f73e7aac8501946f97b66702fdd0/brand_external_report_layout/views/report_template.xml#L19) at line 19.