### PR TITLE
[17.0][FIX] product_brand: use active_id instead of id in the domain field

### DIFF
--- a/product_brand/views/product_brand_view.xml
+++ b/product_brand/views/product_brand_view.xml
@@ -21,7 +21,7 @@
         <field name="res_model">product.brand</field>
         <field name="view_mode">kanban,form,tree</field>
         <field name="target">current</field>
-        <field name="domain">[('product_ids', 'in', id)]</field>
+        <field name="domain">[('product_ids', 'in', active_id)]</field>
     </record>
     <record id="view_product_brand_form" model="ir.ui.view">
         <field name="name">product.brand.form</field>


### PR DESCRIPTION
Open the brand from product's kanban view and error is raise
![image](https://github.com/OCA/brand/assets/7775116/ab83d8fc-27dc-4ab4-9d8a-d4e5f5e8dbde)

This change was done into migration process on https://github.com/OCA/brand/pull/184
CC @lethuthao2403
