### PR TITLE
[17.0][FIX] product_brand: Rule product.brand.public has no group

### DIFF
--- a/product_brand/security/ir.model.access.csv
+++ b/product_brand/security/ir.model.access.csv
@@ -1,3 +1,3 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
 "access_product_brand_product_manager","product.brand","model_product_brand","base.group_partner_manager",1,1,1,1
-"access_product_brand_public","product.brand.public","model_product_brand",,1,0,0,0
+"access_product_brand_public","product.brand.public","model_product_brand",base.group_public,1,0,0,0


### PR DESCRIPTION
* Rule product.brand.public has no group, this is a deprecated feature. 
https://github.com/odoo/odoo/pull/125216

* Every access-granting rule should specify a group. https://github.com/odoo/odoo/commit/ce1a4a2ee00fadf3c09b9dc77baa74c83375331b
