### PR TITLE
[17.0][FIX] product_brand: fix error on clicking brand in product kanban view

### DIFF
--- a/product_brand/views/product_brand_view.xml
+++ b/product_brand/views/product_brand_view.xml
@@ -21,7 +21,7 @@
         <field name="res_model">product.brand</field>
         <field name="view_mode">kanban,form,tree</field>
         <field name="target">current</field>
-        <field name="domain">[('product_ids', 'in', id)]</field>
+        <field name="domain">[('product_ids', 'in', active_id)]</field>
     </record>
     <record id="view_product_brand_form" model="ir.ui.view">
         <field name="name">product.brand.form</field>


### PR DESCRIPTION
This fixes the following error:

```
EvalError: Can not evaluate python expression: ([('product_ids', 'in', id)])
    Error: Name 'id' is not defined
    EvalError: Can not evaluate python expression: ([('product_ids', 'in', id)])
    Error: Name 'id' is not defined
        at evaluateExpr (http://oca-brand-17-0-1589852de24e.runboat.odoo-community.org/web/assets/83b0f05/web.assets_web.min.js:3043:54)
        at _preprocessAction (http://oca-brand-17-0-1589852de24e.runboat.odoo-community.org/web/assets/83b0f05/web.assets_web.min.js:10184:150)
        at doAction (http://oca-brand-17-0-1589852de24e.runboat.odoo-community.org/web/assets/83b0f05/web.assets_web.min.js:10266:170)
        at async Object.doActionButton (http://oca-brand-17-0-1589852de24e.runboat.odoo-community.org/web/assets/83b0f05/web.assets_web.min.js:10274:196)
        at async execute (http://oca-brand-17-0-1589852de24e.runboat.odoo-community.org/web/assets/83b0f05/web.assets_web.min.js:9898:293)
        at async executeButtonCallback (http://oca-brand-17-0-1589852de24e.runboat.odoo-community.org/web/assets/83b0f05/web.assets_web.min.js:9891:34)
```


Steps to reproduce in runbot:

 - go to Invoicing > Products, open one product form and add a brand to the product
 - open the kanban view of products, the brand is shown in the kanban tile of that product
 - click on the brand link: the error is displayed