### PR TITLE
[18.0][FW] [14.0] [IMP] `product_brand`: better position for group by filter in sale.report

### DIFF
--- a/.oca/oca-port/blacklist/product_brand.json
+++ b/.oca/oca-port/blacklist/product_brand.json
@@ -1,0 +1,6 @@
+{
+  "pull_requests": {
+    "OCA/brand#153": "(auto) Nothing to port from PR #153",
+    "OCA/brand#178": "dotfiles update"
+  }
+}

--- a/product_brand/reports/sale_report_view.xml
+++ b/product_brand/reports/sale_report_view.xml
@@ -4,9 +4,9 @@
         <field name="inherit_id" ref="sale.view_order_product_search" />
         <field name="model">sale.report</field>
         <field name="arch" type="xml">
-            <filter name="Customer" position="after">
+            <filter name="Category" position="after">
                 <filter
-                    string="Brand"
+                    string="Product Brand"
                     name="brand"
                     context="{'group_by':'product_brand_id'}"
                 />


### PR DESCRIPTION
Port from 14.0 to 18.0:
- #115

The following PRs have been blacklisted:
- #153: (auto) Nothing to port
- #178: dotfiles update