### PR TITLE
[16.0][REF]brand_external_report_layout: header and footer as Html field.

### DIFF
--- a/brand_external_report_layout/models/res_brand.py
+++ b/brand_external_report_layout/models/res_brand.py
@@ -35,11 +35,11 @@ class ResBrand(models.Model):
     external_report_layout_id = fields.Many2one(
         comodel_name="ir.ui.view", string="Document Template"
     )
-    report_header = fields.Text(
+    report_header = fields.Html(
         help="Appears by default on the top right corner of your printed "
         "documents (report header).",
     )
-    report_footer = fields.Text(
+    report_footer = fields.Html(
         translate=True,
         help="Footer text displayed at the bottom of all reports.",
     )

--- a/brand_external_report_layout/wizards/brand_document_layout.py
+++ b/brand_external_report_layout/wizards/brand_document_layout.py
@@ -20,8 +20,8 @@ class BrandDocumentLayout(models.TransientModel):
     brand_id = fields.Many2one("res.brand", required=True)
 
     logo = fields.Binary(related="brand_id.logo", readonly=False)
-    report_header = fields.Text(related="brand_id.report_header", readonly=False)
-    report_footer = fields.Text(related="brand_id.report_footer", readonly=False)
+    report_header = fields.Html(related="brand_id.report_header", readonly=False)
+    report_footer = fields.Html(related="brand_id.report_footer", readonly=False)
     paperformat_id = fields.Many2one(related="brand_id.paperformat_id", readonly=False)
     external_report_layout_id = fields.Many2one(
         related="brand_id.external_report_layout_id", readonly=False


### PR DESCRIPTION
Hello, I suggest this small refactoring because I believe that using them as Text greatly limits their functionality. Adding them as HTML, just like Odoo does, would be ideal.