### PR TITLE
[16.0][IMP] product_brand: Fix product view

### DIFF
--- a/product_brand/views/product_brand_view.xml
+++ b/product_brand/views/product_brand_view.xml
@@ -136,10 +136,11 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_form_view" />
         <field name="arch" type="xml">
-            <field name="sale_ok" position="before">
-                <field name="product_brand_id" placeholder="Brand" />
-                <div />
-            </field>
+            <div name="options" position="before">
+                <div name="brand">
+                    <field name="product_brand_id" placeholder="Brand" />
+                </div>
+            </div>
         </field>
     </record>
     <record id="view_product_template_kanban_brand" model="ir.ui.view">


### PR DESCRIPTION
### Module

product_brand

### Describe the bug

The product view is not harmonized with the elements of product's header.

### To Reproduce

1. Choose one product and go inside it

(image from runboat OCA)

![Selección_161](https://github.com/user-attachments/assets/133c427b-480c-49db-9120-2d66e57c5615)

With this change, the product view look like this

![imagen](https://github.com/user-attachments/assets/7df42b0c-c82c-4959-8560-5b9979f828cc)

**Affected versions:**

16.0