### PR TITLE
[18.0][FIX] brand: Default Company  for Correct Brand Validation on wizards

### DIFF
--- a/brand/models/res_brand_mixin.py
+++ b/brand/models/res_brand_mixin.py
@@ -28,6 +28,17 @@ class ResBrandMixin(models.AbstractModel):
         compute="_compute_is_brand_required",
     )
 
+    @api.model
+    def default_get(self, fields_list):
+        defaults = super().default_get(fields_list)
+        if "company_id" in fields_list and not defaults.get("company_id"):
+            company_field = self._fields.get("company_id")
+            if company_field is not None and not (
+                company_field.related and company_field.readonly
+            ):
+                defaults["company_id"] = self.env.company.id
+        return defaults
+
     @api.depends("company_id")
     def _compute_is_brand_required(self):
         for record in self:


### PR DESCRIPTION
Defaults the `company_id` field on the `product.pricelist.print` wizard to `self.env.company`.

**Problem:**

The brand requirement validation, which is handled by the `res.brand.mixin` and configured via the `brand_use_level` field on `res.company`, was not consistently being enforced on the "Print Pricelist" wizard (`product.pricelist.print`).

When a company's `brand_use_level` was set to 'required', the wizard did not reliably:
1.  Make the `brand_id` field mandatory in the user interface (UI).
2.  Prevent the user from proceeding if a `brand_id` was not selected, by raising a `ValidationError`.

This was primarily due to the `company_id` field on the `product.pricelist.print` wizard instance (inherited from `res.brand.mixin`) not having an explicit default value. As a result, the related `brand_use_level` field on the wizard might not compute its value correctly at the moment of wizard creation or when UI attributes were determined. This could lead to the mixin's `@api.constrains` (like `_check_brand_requirement`) and its `_get_view` method (which sets UI properties) not functioning with the intended company context.

**Solution:**

This pull request addresses the issue by explicitly setting a default value for the `company_id` field within our inherited `ProductPricelistPrint` model. The `company_id` now defaults to the current user's company:

**More models might benefit from this change as we encountered inconsistent behaviour on the `sale_brand` module as well.**

