### PR TITLE
[16.0][REF]   product_brand: remove unused _group_by override

### DIFF
--- a/product_brand/reports/account_invoice_report.py
+++ b/product_brand/reports/account_invoice_report.py
@@ -16,9 +16,3 @@ class AccountInvoiceReport(models.Model):
             , template.product_brand_id as product_brand_id
             """
         return select_str
-
-    @api.model
-    def _group_by(self):
-        group_by_str = super()._group_by()
-        group_by_str += ", template.product_brand_id"
-        return group_by_str


### PR DESCRIPTION
The method "_group_by" was removed because it is not defined in the parent "account.invoice.report" model, and is not required. Grouping in this report is handled dynamically via the search view ("context={'group_by': ...}"), so a manual SQL "GROUP BY" clause is unnecessary.

@Tecnativa

@carlos-lopez-tecnativa please review