### PR TITLE
[18.0] [IMP] brand - brand_use_level should make brand invisible if 'Do not use brands on business document'

### DIFF
--- a/brand/models/res_brand_mixin.py
+++ b/brand/models/res_brand_mixin.py
@@ -53,34 +53,33 @@ class ResBrandMixin(models.AbstractModel):
     def _get_view(self, view_id=None, view_type="form", **options):
         """set visibility and requirement rules"""
         arch, view = super()._get_view(view_id, view_type, **options)
-        if self.env["res.brand"].check_access("read"):
-            if view.type in ["form", "list"]:
-                brand_node = next(
-                    iter(
-                        arch.xpath(
-                            '//field[@name="brand_id"][not(ancestor::*'
-                            '[@widget="one2many" or @widget="many2many"])]'
-                        )
-                    ),
-                    None,
+        if view.type in ["form", "list"]:
+            brand_node = next(
+                iter(
+                    arch.xpath(
+                        '//field[@name="brand_id"][not(ancestor::*'
+                        '[@widget="one2many" or @widget="many2many"])]'
+                    )
+                ),
+                None,
+            )
+
+            if brand_node is not None:
+                brand_node.addprevious(
+                    E.field(
+                        name="brand_use_level",
+                        invisible="True",
+                        column_invisible="True",
+                    )
                 )
 
-                if brand_node is not None:
-                    brand_node.addprevious(
-                        E.field(
-                            name="brand_use_level",
-                            invisible="True",
-                            column_invisible="True",
-                        )
-                    )
-
-                    brand_node.set(
-                        "invisible",
-                        f"brand_use_level == '{BRAND_USE_LEVEL_NO_USE_LEVEL}'",
-                    )
-                    brand_node.set(
-                        "required",
-                        f"brand_use_level == '{BRAND_USE_LEVEL_REQUIRED_LEVEL}'",
-                    )
+                brand_node.set(
+                    "invisible",
+                    f"brand_use_level == '{BRAND_USE_LEVEL_NO_USE_LEVEL}'",
+                )
+                brand_node.set(
+                    "required",
+                    f"brand_use_level == '{BRAND_USE_LEVEL_REQUIRED_LEVEL}'",
+                )
 
         return arch, view


### PR DESCRIPTION
In this [commit](https://github.com/OCA/brand/commit/9bc550b51c7c5d6305b648c6384ac8da3feea2be) @AntoniRomera adds

`if self.env["res.brand"].check_access_rights("read", raise_exception=False):`

I'm not sure why since we have access right res_brand_access_all that gives read access to everyone.

For migration to 18, this has been rewritten to 

`if self.env["res.brand"].check_access("read"):`

This breaks the use of brand_use_level. Tested with demo or admin: we don't pass in that code anymore because check_access return None when you have access. Therefore we never go in the code inside _get_view of brand module. On the web interface, this leads to have the brand_id field always visible, even if in your configuration you say that you do not want to use brand on business document.