### PR TITLE
[18.0][FIX] product_brand: fix product view alignment

### DIFF
--- a/product_brand/views/product_brand_view.xml
+++ b/product_brand/views/product_brand_view.xml
@@ -125,10 +125,9 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_form_view" />
         <field name="arch" type="xml">
-            <field name="sale_ok" position="before">
+            <xpath expr="//field[@name='sale_ok']/.." position="before">
                 <field name="product_brand_id" placeholder="Brand" />
-                <span />
-            </field>
+            </xpath>
         </field>
     </record>
     <record id="view_product_template_kanban_brand" model="ir.ui.view">


### PR DESCRIPTION
sale_ok and purchase_ok fields are not well aligned after product_brand is installed. This fix re-align the two fields in the same base line.
before:
![image](https://github.com/user-attachments/assets/fdd51e79-47d9-4b51-924f-8291e6f3bb3f)
after:
![image](https://github.com/user-attachments/assets/7c714abb-fea8-45ba-b0c4-1efc2541ed36)
