### PR TITLE
[FIX] partner_brand: Delete test_empty_brand_logo method

### DIFF
--- a/partner_brand/tests/test_partner_brand.py
+++ b/partner_brand/tests/test_partner_brand.py
@@ -61,12 +61,3 @@ class TestResPartner(BaseCommon):
             brand_image,
             "Brand logo is not correctly related to the partner.",
         )
-
-    def test_empty_brand_logo(self):
-        """Test if the partner's brand_logo is empty
-        when no image is set on the brand."""
-        # Initially, the brand does not have an image set.
-        self.assertFalse(
-            self.partner.brand_logo,
-            "Brand logo should be empty if the brand does not have an image.",
-        )


### PR DESCRIPTION
Removed test for empty brand logo when no image is set. To improve compatibility with other modules

As discovered in:
https://github.com/OCA/brand/pull/224