### PR TITLE
[18.0][IMP] account_brand: compute account_id at move_line creation

### DIFF
--- a/account_brand/models/__init__.py
+++ b/account_brand/models/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2019 Open Source Integrators
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from . import account_move_line
 from . import account_move
 from . import res_partner_account_brand

--- a/account_brand/models/account_move.py
+++ b/account_brand/models/account_move.py
@@ -17,23 +17,22 @@ class AccountMove(models.Model):
             return False
         return super()._is_brand_required()
 
-    @api.onchange("partner_id")
-    def _onchange_partner_id(self):
-        res = super()._onchange_partner_id()
-        if self.brand_id:
-            pab_model = self.env["res.partner.account.brand"]
-            company_id = self.company_id.id
+    @api.onchange("partner_id", "brand_id", "company_id")
+    def _onchange_lines_account_id_from_brand(self):
+        pab_model = self.env["res.partner.account.brand"]
+        for move in self.filtered("brand_id"):
+            company_id = move.company_id.id
             partner = (
-                self.partner_id
+                move.partner_id
                 if not company_id
-                else self.partner_id.with_company(company_id)
+                else move.partner_id.with_company(company_id)
             )
-            invoice_type = self.move_type or self.env.context.get(
+            invoice_type = move.move_type or self.env.context.get(
                 "move_type", "out_invoice"
             )
             if partner:
                 rec_account = pab_model._get_partner_account_by_brand(
-                    "asset_receivable", self.brand_id, partner
+                    "asset_receivable", move.brand_id, partner
                 )
                 rec_account = (
                     rec_account
@@ -41,7 +40,7 @@ class AccountMove(models.Model):
                     else partner.property_account_receivable_id
                 )
                 pay_account = pab_model._get_partner_account_by_brand(
-                    "liability_payable", self.brand_id, partner
+                    "liability_payable", move.brand_id, partner
                 )
                 pay_account = (
                     pay_account if pay_account else partner.property_account_payable_id
@@ -51,8 +50,7 @@ class AccountMove(models.Model):
                 else:
                     account_id = rec_account
                 if account_id:
-                    self.line_ids.filtered(
+                    move.line_ids.filtered(
                         lambda line, a=account_id: line.account_id.account_type
                         == a.account_type
                     ).update({"account_id": account_id.id})
-        return res

--- a/account_brand/models/account_move_line.py
+++ b/account_brand/models/account_move_line.py
@@ -1,0 +1,14 @@
+# Copyright 2025 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move.line"
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        res = super().create(vals_list)
+        res.mapped("move_id")._onchange_lines_account_id_from_brand()
+        return res

--- a/account_brand/tests/test_account_move.py
+++ b/account_brand/tests/test_account_move.py
@@ -77,11 +77,11 @@ class TestAccountMove(TransactionCase):
                 "account_type": "asset_receivable",
             }
         )
-        self.move._onchange_partner_id()
+        self.move._onchange_lines_account_id_from_brand()
         account = self._get_receivable_account(self.move)
         self.assertEqual(account, self.account_receivable)
         self.move.brand_id = self.brand_id
-        self.move._onchange_partner_id()
+        self.move._onchange_lines_account_id_from_brand()
         account = self._get_receivable_account(self.move)
         self.assertEqual(account, self.account_receivable_brand_default)
         partner_account_brand.update(
@@ -90,7 +90,7 @@ class TestAccountMove(TransactionCase):
                 "account_id": self.account_receivable_partner_brand_default.id,
             }
         )
-        self.move._onchange_partner_id()
+        self.move._onchange_lines_account_id_from_brand()
         account = self._get_receivable_account(self.move)
         self.assertEqual(
             account,
@@ -108,3 +108,34 @@ class TestAccountMove(TransactionCase):
             account,
             self.account_receivable_partner_brand_default,
         )
+
+    def test_add_new_line(self):
+        self.env["res.partner.account.brand"].create(
+            {
+                "partner_id": False,
+                "account_id": self.account_receivable_brand_default.id,
+                "brand_id": self.brand_id.id,
+                "account_type": "asset_receivable",
+            }
+        )
+        self.move.write(
+            {
+                "brand_id": self.brand_id.id,
+                "invoice_line_ids": [
+                    (5, 0, 0),
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product.id,
+                            "quantity": 1,
+                            "price_unit": 42,
+                            "name": "something",
+                            "account_id": self.account_revenue.id,
+                        },
+                    ),
+                ],
+            }
+        )
+        account = self._get_receivable_account(self.move)
+        self.assertEqual(account, self.account_receivable_brand_default)


### PR DESCRIPTION
This module has changed a lot between Odoo versions, especially in version 13.0 and 16.0 where the method `_recompute_payment_terms_lines()` has been added then removed. 
I believe some features got lost on the way.

Today I don't understand how it is supposed to work anymore. For me:
1. The account should be computed when a new move line is added, not only when the onchange triggers on the move.
2. The onchange on the move should also trigger if the brand or the company changes (it was the case until migration to 13.0).