### PR TITLE
[18.0] [IMP] contract_brand: add unit test case

### DIFF
--- a/contract_brand/tests/test_contract.py
+++ b/contract_brand/tests/test_contract.py
@@ -18,6 +18,15 @@ class TestContract(TestContractBase):
                 "plan_id": cls.analytic_plan.id,
             }
         )
+        cls.analytic_plan2 = cls.env["account.analytic.plan"].create(
+            {"name": "analytic plan 2"}
+        )
+        cls.analytic_account2 = cls.env["account.analytic.account"].create(
+            {
+                "name": "analytic account 2",
+                "plan_id": cls.analytic_plan2.id,
+            }
+        )
 
     def test_contract_create_branded_move(self):
         """It should create a branded move based on the contract brand"""
@@ -39,3 +48,32 @@ class TestContract(TestContractBase):
         self.contract.brand_id = self.brand_id
         for line in self.contract.contract_line_ids:
             self.assertEqual(line.analytic_distribution, analytic_distribution)
+
+    def test_contract_analytic_distribution_combined(self):
+        """
+        Analytic distribution model for the product + analytic on the brand
+        -> Combine both
+        """
+        contract_line = self.contract.contract_line_ids[0]
+        product = contract_line.product_id
+        self.env["account.analytic.distribution.model"].create(
+            {
+                "product_id": product.id,
+                "analytic_distribution": {str(self.analytic_account.id): 100},
+            }
+        )
+        contract_line._compute_analytic_distribution()
+        self.assertEqual(
+            contract_line.analytic_distribution, {str(self.analytic_account.id): 100}
+        )
+        self.env["account.analytic.distribution.model"].create(
+            {
+                "brand_id": self.brand_id.id,
+                "analytic_distribution": {str(self.analytic_account2.id): 100},
+            }
+        )
+        self.contract.brand_id = self.brand_id
+        self.assertEqual(
+            contract_line.analytic_distribution,
+            {str(self.analytic_account.id): 100, str(self.analytic_account2.id): 100},
+        )


### PR DESCRIPTION
This PR originally fixed a problem on contract_brand when combining analytic distribution defined by analytic distribution models with analytic on brands.

However with PR https://github.com/OCA/brand/pull/286 and the refactoring on analytic on brands this fix was covered.

This PR just adds the unit test case to ensure a non-regression.