### PR TITLE
[16.0][FIX] brand: Enable overloading of res.brand.mixin views

### DIFF
--- a/brand/models/res_brand_mixin.py
+++ b/brand/models/res_brand_mixin.py
@@ -4,6 +4,7 @@ from lxml import etree
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+from odoo.osv import expression
 
 from odoo.addons.base.models import ir_ui_view
 
@@ -57,8 +58,24 @@ class ResBrandMixin(models.AbstractModel):
         attributes = ["invisible", "readonly", "required"]
         if field is not None:
             ir_ui_view.transfer_field_to_modifiers(field, modifiers, attributes)
+            if self.is_brand_id_field(field) and self._get_brand_id_readonly_domain():
+                if isinstance(modifiers["readonly"], list):
+                    modifiers["readonly"] = expression.OR(
+                        [
+                            modifiers["readonly"],
+                            self._get_brand_id_readonly_domain(),
+                        ]
+                    )
+                else:
+                    modifiers["readonly"] = self._get_brand_id_readonly_domain()
         ir_ui_view.transfer_node_to_modifiers(node, modifiers)
         ir_ui_view.transfer_modifiers_to_node(modifiers, node)
+
+    def is_brand_id_field(self, field):
+        return field == self.fields_get(["brand_id"])["brand_id"]
+
+    def _get_brand_id_readonly_domain(self):
+        return False
 
     @api.model
     def get_view(self, view_id=None, view_type="form", **options):


### PR DESCRIPTION
With the get_view() function in the res.brand.mixin template, all view overrides for the brand_id field are systematically overwritten by the Python definition of the field.

As a result, the sale_brand.view_order_form_brand view is useless because the definition of the SaleOrder.brand_id field already sets it to read-only in all states other than ‘draft’.

This proposal intends to make the "readonly" attribute of the brand_id field in views overridable via a Python function.