### PR TITLE
[18.0][FIX] analytic_brand refactoring post-migration script

### DIFF
--- a/analytic_brand/migrations/18.0.2.0.0/post-migrate.py
+++ b/analytic_brand/migrations/18.0.2.0.0/post-migrate.py
@@ -7,6 +7,31 @@ from openupgradelib import openupgrade
 _logger = logging.getLogger(__name__)
 
 
+def _find_company_from_analytic_distribution(env, analytic_distribution):
+    # Take inspiration from Odoo method _compute_distribution_analytic_account_ids
+    # on analytic.mixin
+    account_ids = {int(_id) for key in analytic_distribution for _id in key.split(";")}
+    env.cr.execute(
+        """
+        SELECT DISTINCT company_id
+        FROM account_analytic_account
+        WHERE id IN %(account_ids)s
+        """,
+        {
+            "account_ids": tuple(account_ids),
+        },
+    )
+    res = env.cr.fetchall()
+    if not res:
+        return False
+    if len(res) > 1:
+        _logger.error(
+            "Analytic distribution %s mixes accounts from several companies",
+            analytic_distribution,
+        )
+    return res[0][0]
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     _logger.info("Delete res.brand form view")
@@ -25,7 +50,14 @@ def migrate(env, version):
     res = env.cr.fetchall()
     vals_create = []
     for brand_id, analytic_distribution in res:
+        company_id = _find_company_from_analytic_distribution(
+            env, analytic_distribution
+        )
         vals_create.append(
-            {"brand_id": brand_id, "analytic_distribution": analytic_distribution}
+            {
+                "brand_id": brand_id,
+                "analytic_distribution": analytic_distribution,
+                "company_id": company_id,
+            }
         )
     env["account.analytic.distribution.model"].create(vals_create)


### PR DESCRIPTION
[18.0][FIX] analytic_brand refactoring post-migration script
Create analytic distribution models using the right company.

Before this commit the post-migration 18.0.2.0.0 script in analytic_brand created analytic distribution models from brands shared on all companies. But if the analytic accounts of the existing analytic distributions belonged to a specific company, Odoo raises an error if the analytic distribution model is not linked to that company.

This commit fixes the migration script by looking for the right company from the analytic accounts present in the analytic distribution.

This PR is a fix following the merge of https://github.com/OCA/brand/pull/286
