### PR TITLE
[18.0][FIX] account_brand: Fix dynamic domain on account_id

### DIFF
--- a/account_brand/models/res_partner_account_brand.py
+++ b/account_brand/models/res_partner_account_brand.py
@@ -19,7 +19,10 @@ class ResPartnerAccountBrand(models.Model):
         comodel_name="account.account",
         string="Account",
         required=True,
-        domain="[('account_type', 'in', ('liability_payable', 'asset_receivable'))]",
+        domain=(
+            "[('account_type', '=', account_type), ('deprecated', '=', False)] "
+            "if account_type else [('id', '=', False)]"
+        ),
     )
     brand_id = fields.Many2one(comodel_name="res.brand", string="Brand", required=True)
     account_type = fields.Selection(
@@ -53,20 +56,7 @@ class ResPartnerAccountBrand(models.Model):
 
     @api.onchange("account_type")
     def _onchange_account_type(self):
-        self.ensure_one()
-        self.update({"account_id": False})
-        domain = [("id", "=", False)]
-        if self.account_type == "payable":
-            domain = [
-                ("internal_type", "=", "payable"),
-                ("deprecated", "=", False),
-            ]
-        elif self.account_type == "receivable":
-            domain = [
-                ("internal_type", "=", "receivable"),
-                ("deprecated", "=", False),
-            ]
-        return {"domain": {"account_id": domain}}
+        self.account_id = False
 
     @api.model
     def _get_partner_account_by_brand(self, account_type, brand, partner):


### PR DESCRIPTION
## Summary
From v14, Returning a domain dict from _onchange_account_type is deprecated. The domain is moved directly onto the account_id field definition using a dynamic expression referencing account_type. Also, in v16+ the internal_type field on account.account was replaced by account_type.

## Changes
- Replace deprecated onchange domain return with a declarative field domain.
- Use account_type field (replaces deprecated internal_type from v14).
- Simplify _onchange_account_type to only reset account_id.