### PR TITLE
[18.0][FIX] mail_brand: Brand not pre-filled in email compose wizard

### DIFF
--- a/mail_brand/wizard/mail_compose_message.py
+++ b/mail_brand/wizard/mail_compose_message.py
@@ -1,5 +1,7 @@
 from odoo import api, fields, models
 
+from odoo.addons.mail.tools.parser import parse_res_ids
+
 
 class MailComposeMessageExt(models.TransientModel):
     _inherit = "mail.compose.message"
@@ -9,15 +11,19 @@ class MailComposeMessageExt(models.TransientModel):
     @api.model
     def default_get(self, fields):
         result = super().default_get(fields)
-        model = result.get("model")
-        res_id = result.get("res_id")
+        if "brand_id" not in fields:
+            return result
 
-        if model and res_id and "brand_id" in fields:
-            model_object = self.env[model].browse(res_id)
-            if hasattr(model_object, "brand_id") and model_object.brand_id:
-                result["brand_id"] = model_object.brand_id.id
-        else:
-            result["brand_id"] = self.brand_id
+        # In v18 res_id (integer) was replaced by res_ids (Text, JSON list);
+        # the chatter passes default_res_ids/default_model instead of active_id.
+        model = result.get("model")
+        res_ids_raw = result.get("res_ids")
+        if model and res_ids_raw:
+            res_ids = parse_res_ids(res_ids_raw, self.env)
+            if res_ids:
+                model_object = self.env[model].browse(res_ids[0])
+                if hasattr(model_object, "brand_id") and model_object.brand_id:
+                    result["brand_id"] = model_object.brand_id.id
 
         return result
 


### PR DESCRIPTION
- When opening the "Send Email" composer from a record that has a brand set, the Brand field was not being pre-populated.

- The root cause is an API change in mail.compose.message: the res_id integer field was removed and replaced by res_ids, a Text field storing the record IDs as a JSON list. The old code was reading result.get("res_id") which is always None, so the auto-populate logic never ran.

- The fix reads res_ids instead and uses odoo's own parse_res_ids helper to extract the active record ID.

- The stale else branch that set result["brand_id"] = self.brand_id was also removed — in an @api.model method self carries no record, so this always evaluated to False and was silently overwriting any default_brand_id value passed in context.