### PR TITLE
[18.0][FIX] mail_brand: typo in get_base_url (website_website_id -> website_id)

### DIFF
--- a/mail_brand/models/ir_model.py
+++ b/mail_brand/models/ir_model.py
@@ -10,7 +10,11 @@ class BaseModel(models.AbstractModel):
     def get_base_url(self):
         if not self:
             return super().get_base_url()
-        if "brand_id" in self and "website_id" in self.brand_id:
-            return self.brand_id.website_website_id.domain
+        if (
+            "brand_id" in self
+            and "website_id" in self.brand_id
+            and self.brand_id.website_id.domain
+        ):
+            return self.brand_id.website_id.domain
         else:
             return super().get_base_url()


### PR DESCRIPTION
Fixes #287

   The `get_base_url` method in `mail_brand` referenced a non-existent
   field `website_website_id` on `res.brand`, causing an AttributeError
   when sending an email/message from a document linked to a brand.

   The correct field is `website_id`.