### PR TITLE
[18.0][FIX] brand: improve spacing in kanban cards

### DIFF
--- a/brand/views/res_brand.xml
+++ b/brand/views/res_brand.xml
@@ -133,7 +133,7 @@
                         <field
                             name="image_128"
                             widget="image"
-                            class="h-100"
+                            class="h-100 me-2"
                             options="{'img_class': 'object-fit-cover'}"
                         />
                         <main class="ps-2 ps-md-0">


### PR DESCRIPTION
## Current behavior

The brand logo and text in the kanban view are displayed too close to each other, which makes the card look cramped.

## Desired behavior

Add a small spacing between the logo and the text to improve readability and visual appearance.

## Solution

Add a Bootstrap spacing utility (`me-2`) to separate the logo from the brand information.

<img width="1116" height="498" alt="image" src="https://github.com/user-attachments/assets/29982f33-a046-4cff-b559-2b58bc98b696" />


### After

<img width="1381" height="495" alt="image" src="https://github.com/user-attachments/assets/395891fb-4824-4f50-91f5-ebe0660ad93c" />